### PR TITLE
Adding build workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Rename artifacts
         run: mv ./target/release/governance2 ./target/release/governance2-${{ env.tag }}
 
+      - name: ➡️ Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bin
+          path: ./target/release/governance2-${{ env.tag }}
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,40 @@
+name: Publish GitHub release
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+
+env:
+  tag: v1.0.0
+  message: test_tag
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    container:
+      image: paritytech/ci-linux:1c0fde6a-20220811
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{ env.tag }}
+          message: ${{ env.message }}
+
+      - name: Build release
+        run: cargo build --release
+
+      - name: Rename artifacts
+        run: mv ./target/release/governance2 ./target/release/governance2-${{ env.tag }}
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.tag }}
+          name: ${{ env.message }}
+          draft: false
+          files: ./target/release/governance2-${{ env.tag }}
+

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,12 +2,16 @@ name: Publish GitHub release
 
 on:
   workflow_dispatch:
-  pull_request:
+    inputs:
+      tag:
+        description: 'Tag name'
+        required: true
+        default: v*.*.*
+      release_name:
+        description: 'Special name changes'
+        required: true
+        default: Describe here what was changed
 
-
-env:
-  tag: v1.0.0
-  message: test_tag
 
 jobs:
   create-release:
@@ -20,27 +24,27 @@ jobs:
 
       - uses: rickstaa/action-create-tag@v1
         with:
-          tag: ${{ env.tag }}
-          message: ${{ env.message }}
+          tag: ${{ github.event.inputs.tag }}
+          message: ${{ github.event.inputs.release_name }}
 
       - name: Build release
         run: cargo build --release
 
       - name: Rename artifacts
-        run: mv ./target/release/governance2 ./target/release/governance2-${{ env.tag }}
+        run: mv ./target/release/governance2 ./target/release/governance2-${{ github.event.inputs.tag }}
 
       - name: ➡️ Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
           name: bin
-          path: ./target/release/governance2-${{ env.tag }}
+          path: ./target/release/governance2-${{ github.event.inputs.tag }}
 
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ env.tag }}
-          name: ${{ env.message }}
+          tag_name: ${{ github.event.inputs.tag }}
+          name: ${{ github.event.inputs.release_name }}
           draft: false
-          files: ./target/release/governance2-${{ env.tag }}
+          files: ./target/release/governance2-${{ github.event.inputs.tag }}
 

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -1,15 +1,15 @@
 name: Build & Test
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "**/dependabot.yml"
-      - "**/README.md"
-  pull_request:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
+  #   paths-ignore:
+  #     - "**/dependabot.yml"
+  #     - "**/README.md"
+  # pull_request:
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
This PR adds workflow for build binary file for governance_v2 testing.

It is manual workflow.
Inputs:
- tag
- name of changes

After the workflow have been run the workflow will create a {tag} and publish release {name of changes}, as artefacts will attach the binary file.